### PR TITLE
sidekiq-unique-jobs-7.1.4 does not exist upgrading to sidekiq-unique-jobs-7.1.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,7 +301,7 @@ GEM
     rainbow (3.0.0)
     rake (13.0.6)
     recursive-open-struct (1.1.3)
-    redis (4.3.1)
+    redis (4.4.0)
     regexp_parser (2.1.1)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
@@ -383,7 +383,7 @@ GEM
     sidekiq-statistic (1.4.0)
       sidekiq (>= 5.0)
       tilt (~> 2.0)
-    sidekiq-unique-jobs (7.1.4)
+    sidekiq-unique-jobs (7.1.5)
       brpoplpush-redis_script (> 0.1.1, <= 2.0.0)
       concurrent-ruby (~> 1.0, >= 1.0.5)
       sidekiq (>= 5.0, < 7.0)
@@ -515,4 +515,4 @@ RUBY VERSION
    ruby 2.7.3p183
 
 BUNDLED WITH
-   2.2.16
+   2.2.24


### PR DESCRIPTION
```shell
bundle
Fetching gem metadata from https://rubygems.org/
Fetching gem metadata from https://rubygems.org/.........
Could not find sidekiq-unique-jobs-7.1.4 in any of the sources
```

I'm guessing it got pulled for some reason

![Screen Shot 2021-08-12 at 8 14 49 PM](https://user-images.githubusercontent.com/13140/129299930-b5f0c809-ab16-44af-9b8e-39489c623b12.png)

