### PR TITLE
Enhance AWS config

### DIFF
--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 require 'aws-sdk-s3'
 
-Aws.config.update(
-  region: ENV['RESPONSE_IMAGE_AWS_REGION'],
-  credentials: Aws::Credentials.new(
-    ENV['RESPONSE_IMAGE_AWS_ACCESS_KEY_ID'],
-    ENV['RESPONSE_IMAGE_AWS_SECRET_ACCESS_KEY']
+if ENV['AWS_ROLE_ARN'].present? && ENV['AWS_WEB_IDENTITY_TOKEN_FILE'].present?
+  Aws.config.update(
+    credentials: Aws::AssumeRoleWebIdentityCredentials.new(
+      client: Aws::STS::Client.new,
+      role_arn: ENV['AWS_ROLE_ARN'],
+      web_identity_token_file: ENV['AWS_WEB_IDENTITY_TOKEN_FILE'],
+      role_session_name: "kudochest-#{Rails.env}-session"
+    )
   )
-)
+end


### PR DESCRIPTION
Rely on AWS SDK default environment variables and use `AssumeRoleWebIdentityCredentials` if env vars present.