### PR TITLE
Fix subteam sync dupe member issue

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -58,6 +58,7 @@ class Profile < ApplicationRecord
     where(rid: profile_rids)
       .joins(:team)
       .where('teams.rid' => team_rid)
+      .distinct
   end
 
   def self.find_with_team(team_rid, profile_rid)

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -162,8 +162,8 @@ class Team < ApplicationRecord
 
   def sync_remote(first_run: false)
     return unless active?
-    ChannelWorker.perform_async(rid)
-    ProfileWorker.perform_async(rid, first_run)
+    ChannelSyncWorker.perform_async(rid)
+    TeamSyncWorker.perform_async(rid, first_run)
     EmojiInstallWorker.perform_async(rid) if first_run && platform.discord?
   end
 

--- a/app/services/actions/channel_sync.rb
+++ b/app/services/actions/channel_sync.rb
@@ -7,7 +7,7 @@ class Actions::ChannelSync < Actions::Base
   private
 
   def sync_channels
-    ChannelWorker.perform_async(params[:team_rid], new_channel_rid)
+    ChannelSyncWorker.perform_async(params[:team_rid], new_channel_rid)
   end
 
   def new_channel_rid

--- a/app/services/actions/subteam_sync.rb
+++ b/app/services/actions/subteam_sync.rb
@@ -7,6 +7,6 @@ class Actions::SubteamSync < Actions::Base
   private
 
   def sync_subteam
-    SubteamWorker.perform_async(params[:team_rid])
+    SubteamSyncWorker.perform_async(params[:team_rid])
   end
 end

--- a/app/services/actions/team_join.rb
+++ b/app/services/actions/team_join.rb
@@ -7,6 +7,6 @@ class Actions::TeamJoin < Actions::Base
   private
 
   def sync_team_profiles
-    ProfileWorker.perform_async(params[:team_rid])
+    TeamSyncWorker.perform_async(params[:team_rid])
   end
 end

--- a/app/services/base/channel_sync_service.rb
+++ b/app/services/base/channel_sync_service.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class Base::ChannelService < Base::Service
+class Base::ChannelSyncService < Base::Service
   option :team
   option :new_channel_rid
 

--- a/app/services/base/subteam_sync_service.rb
+++ b/app/services/base/subteam_sync_service.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class Base::SubteamService < Base::Service
+class Base::SubteamSyncService < Base::Service
   option :team
 
   def call

--- a/app/services/base/team_sync_service.rb
+++ b/app/services/base/team_sync_service.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class Base::ProfileService < Base::Service
+class Base::TeamSyncService < Base::Service
   option :team
   option :first_run, default: proc { false }
 
@@ -31,7 +31,7 @@ class Base::ProfileService < Base::Service
   end
 
   def sync_subteams
-    SubteamWorker.perform_async(team.rid)
+    SubteamSyncWorker.perform_async(team.rid)
   end
 
   def sync_profiles

--- a/app/services/discord/bot_event_service.rb
+++ b/app/services/discord/bot_event_service.rb
@@ -27,49 +27,49 @@ class Discord::BotEventService < Base::Service
   def listen_for_channel_create
     bot.channel_create do |event|
       next unless (team_rid = event.server&.id&.to_s) # Appears when DMing a user (?!)
-      ChannelWorker.perform_async(team_rid)
+      ChannelSyncWorker.perform_async(team_rid)
     end
   end
 
   def listen_for_channel_delete
     bot.channel_delete do |event|
-      ChannelWorker.perform_async(event.server.id.to_s)
+      ChannelSyncWorker.perform_async(event.server.id.to_s)
     end
   end
 
   def listen_for_role_create
     bot.server_role_create do |event|
-      SubteamWorker.perform_async(event.server.id.to_s)
+      SubteamSyncWorker.perform_async(event.server.id.to_s)
     end
   end
 
   def listen_for_role_update
     bot.server_role_update do |event|
-      SubteamWorker.perform_async(event.server.id.to_s)
+      SubteamSyncWorker.perform_async(event.server.id.to_s)
     end
   end
 
   def listen_for_role_delete
     bot.server_role_delete do |event|
-      SubteamWorker.perform_async(event.server.id.to_s)
+      SubteamSyncWorker.perform_async(event.server.id.to_s)
     end
   end
 
   def listen_for_member_join
     bot.member_join do |event|
-      ProfileWorker.perform_async(event.server.id.to_s)
+      TeamSyncWorker.perform_async(event.server.id.to_s)
     end
   end
 
   def listen_for_member_leave
     bot.member_leave do |event|
-      ProfileWorker.perform_async(event.server.id.to_s)
+      TeamSyncWorker.perform_async(event.server.id.to_s)
     end
   end
 
   def listen_for_member_update
     bot.member_update do |event|
-      ProfileWorker.perform_async(event.server.id.to_s) # Profile attributes
+      TeamSyncWorker.perform_async(event.server.id.to_s) # Profile attributes
     end
   end
 

--- a/app/services/discord/channel_sync_service.rb
+++ b/app/services/discord/channel_sync_service.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class Discord::ChannelService < Base::ChannelService
+class Discord::ChannelSyncService < Base::ChannelSyncService
   def fetch_remote_channels
     JSON.parse(discord_response, symbolize_names: true)
         .select { |d| d[:type].zero? } # Text channels only

--- a/app/services/discord/subteam_sync_service.rb
+++ b/app/services/discord/subteam_sync_service.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class Discord::SubteamService < Base::SubteamService
+class Discord::SubteamSyncService < Base::SubteamSyncService
   private
 
   def profile_rids_for(role)

--- a/app/services/discord/team_sync_service.rb
+++ b/app/services/discord/team_sync_service.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class Discord::ProfileService < Base::ProfileService
+class Discord::TeamSyncService < Base::TeamSyncService
   private
 
   def fetch_team_members

--- a/app/services/slack/channel_sync_service.rb
+++ b/app/services/slack/channel_sync_service.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class Slack::ChannelService < Base::ChannelService
+class Slack::ChannelSyncService < Base::ChannelSyncService
   def call
     super
     join_new_channel

--- a/app/services/slack/subteam_sync_service.rb
+++ b/app/services/slack/subteam_sync_service.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class Slack::SubteamService < Base::SubteamService
+class Slack::SubteamSyncService < Base::SubteamSyncService
   private
 
   def profile_rids_for(subteam)

--- a/app/services/slack/team_sync_service.rb
+++ b/app/services/slack/team_sync_service.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class Slack::ProfileService < Base::ProfileService
+class Slack::TeamSyncService < Base::TeamSyncService
   private
 
   def fetch_team_members

--- a/app/workers/channel_sync_worker.rb
+++ b/app/workers/channel_sync_worker.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
-class ChannelWorker
+class ChannelSyncWorker
   include Sidekiq::Worker
   sidekiq_options queue: :channel_sync, lock: :until_executed
 
   def perform(team_rid, new_channel_rid = nil)
     team = Team.find_by!(rid: team_rid)
     return unless team.active?
-    "#{team.plat}::ChannelService".constantize.call(team:, new_channel_rid:)
+    "#{team.plat}::ChannelSyncService".constantize.call(team:, new_channel_rid:)
   end
 end

--- a/app/workers/subteam_sync_worker.rb
+++ b/app/workers/subteam_sync_worker.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
-class SubteamWorker
+class SubteamSyncWorker
   include Sidekiq::Worker
   sidekiq_options queue: :team_sync, lock: :until_and_while_executing
 
   def perform(team_rid)
     team = Team.find_by!(rid: team_rid)
     return unless team.active?
-    "#{team.plat}::SubteamService".constantize.call(team:)
+    "#{team.plat}::SubteamSyncService".constantize.call(team:)
   end
 end

--- a/app/workers/team_sync_worker.rb
+++ b/app/workers/team_sync_worker.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
-class ProfileWorker
+class TeamSyncWorker
   include Sidekiq::Worker
   sidekiq_options queue: :team_sync, lock: :until_executed
 
   def perform(team_rid, first_run = false)
     team = Team.find_by!(rid: team_rid)
     return unless team.active?
-    "#{team.plat}::ProfileService".constantize.call(team:, first_run:)
+    "#{team.plat}::TeamSyncService".constantize.call(team:, first_run:)
   end
 end

--- a/app/workers/weekly_report/profile_worker.rb
+++ b/app/workers/weekly_report/profile_worker.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class WeeklyReport::ProfileWorker
+class WeeklyReport::TeamSyncWorker
   include ActionView::Helpers::TextHelper
   include PointsHelper
   include Sidekiq::Worker

--- a/app/workers/weekly_report/recurrent_worker.rb
+++ b/app/workers/weekly_report/recurrent_worker.rb
@@ -22,7 +22,7 @@ class WeeklyReport::RecurrentWorker
   def run_profile_report_workers
     Profile.where(weekly_report: true).find_each do |profile|
       next unless profile.active? && profile.team.active?
-      WeeklyReport::ProfileWorker.perform_async(profile.id)
+      WeeklyReport::TeamSyncWorker.perform_async(profile.id)
     end
   end
 end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -94,17 +94,17 @@ RSpec.describe Team do
     subject(:team) { create(:team, active: false) }
 
     before do
-      allow(ChannelWorker).to receive(:perform_async)
-      allow(ProfileWorker).to receive(:perform_async)
+      allow(ChannelSyncWorker).to receive(:perform_async)
+      allow(TeamSyncWorker).to receive(:perform_async)
       team.update(active: true)
     end
 
-    it 'calls ChannelWorker' do
-      expect(ChannelWorker).to have_received(:perform_async).with(team.rid)
+    it 'calls ChannelSyncWorker' do
+      expect(ChannelSyncWorker).to have_received(:perform_async).with(team.rid)
     end
 
-    it 'calls ProfileWorker' do
-      expect(ProfileWorker).to have_received(:perform_async).with(team.rid, false)
+    it 'calls TeamSyncWorker' do
+      expect(TeamSyncWorker).to have_received(:perform_async).with(team.rid, false)
     end
   end
 

--- a/spec/services/actions/channel_sync_spec.rb
+++ b/spec/services/actions/channel_sync_spec.rb
@@ -20,12 +20,12 @@ RSpec.describe Actions::ChannelSync do
   let(:team) { build(:team) }
 
   before do
-    allow(ChannelWorker).to receive(:perform_async)
+    allow(ChannelSyncWorker).to receive(:perform_async)
   end
 
-  it 'calls ChannelWorker' do
+  it 'calls ChannelSyncWorker' do
     action
-    expect(ChannelWorker).to have_received(:perform_async).with(team.rid, 'new_channel_rid')
+    expect(ChannelSyncWorker).to have_received(:perform_async).with(team.rid, 'new_channel_rid')
   end
 
   it 'responds silently' do

--- a/spec/services/actions/subteam_sync_spec.rb
+++ b/spec/services/actions/subteam_sync_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe Actions::SubteamSync do
   let(:params) { { team_rid: team.rid } }
 
   before do
-    allow(SubteamWorker).to receive(:perform_async)
+    allow(SubteamSyncWorker).to receive(:perform_async)
   end
 
-  it 'calls SubteamWorker' do
+  it 'calls SubteamSyncWorker' do
     action
-    expect(SubteamWorker).to have_received(:perform_async).with(team.rid)
+    expect(SubteamSyncWorker).to have_received(:perform_async).with(team.rid)
   end
 
   it 'responds silently' do

--- a/spec/services/actions/team_join_spec.rb
+++ b/spec/services/actions/team_join_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe Actions::TeamJoin do
   let(:params) { { team_rid: team.rid } }
 
   before do
-    allow(ProfileWorker).to receive(:perform_async)
+    allow(TeamSyncWorker).to receive(:perform_async)
   end
 
-  it 'calls ProfileWorker' do
+  it 'calls TeamSyncWorker' do
     action
-    expect(ProfileWorker).to have_received(:perform_async).with(team.rid)
+    expect(TeamSyncWorker).to have_received(:perform_async).with(team.rid)
   end
 
   it 'responds silently' do

--- a/spec/services/discord/channel_sync_service_spec.rb
+++ b/spec/services/discord/channel_sync_service_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe Discord::ChannelService, vcr: {
-  cassette_name: 'discord/ChannelService/fetch_channels'
+RSpec.describe Discord::ChannelSyncService, vcr: {
+  cassette_name: 'discord/ChannelSyncService/fetch_channels'
 } do
   let(:mock_data) do
     [
@@ -41,5 +41,5 @@ RSpec.describe Discord::ChannelService, vcr: {
   end
 
   # TODO: This needs to be Discord-specific (record the cassette)
-  # include_examples 'ChannelService'
+  # include_examples 'ChannelSyncService'
 end

--- a/spec/services/discord/subteam_sync_service_spec.rb
+++ b/spec/services/discord/subteam_sync_service_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe Discord::SubteamService do
+RSpec.describe Discord::SubteamSyncService do
   let(:expected_names) { ['Test Group 3', 'Test Group 4'] }
   let(:expected_profile_rids) { %w[profile-1 profile-2] }
   let(:expected_name) { 'Test Group 4' }
@@ -53,5 +53,5 @@ RSpec.describe Discord::SubteamService do
     end
   end
 
-  include_examples 'SubteamService'
+  include_examples 'SubteamSyncService'
 end

--- a/spec/services/discord/team_sync_service_spec.rb
+++ b/spec/services/discord/team_sync_service_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe Discord::ProfileService do
+RSpec.describe Discord::TeamSyncService do
   let(:expected_names) { %w[Existing Mark Vincent William Wolfgang] }
   let(:profile_data) do
     expected_names[1..].map do |username|
@@ -35,7 +35,7 @@ RSpec.describe Discord::ProfileService do
       .with(App.discord_token, team.rid, 1_000).and_return(profile_data.to_json)
   end
 
-  include_examples 'ProfileService'
+  include_examples 'TeamSyncService'
 
   xcontext 'when avatar is missing' do
     it 'assigns a default one' do

--- a/spec/services/slack/channel_sync_service_spec.rb
+++ b/spec/services/slack/channel_sync_service_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe Slack::ChannelService, vcr: { cassette_name: 'slack/channel_service' } do
+RSpec.describe Slack::ChannelSyncService, vcr: { cassette_name: 'slack/channel_service' } do
   let(:new_channel_rid) { 'C0103NCM3L2' } # `bot` channel
 
-  include_examples 'ChannelService'
+  include_examples 'ChannelSyncService'
 
   it 'joins new channel' do
     expect(Slack::ChannelJoinService)

--- a/spec/services/slack/subteam_sync_service_spec.rb
+++ b/spec/services/slack/subteam_sync_service_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe Slack::SubteamService, vcr: { cassette_name: 'slack/subteam_service' } do
+RSpec.describe Slack::SubteamSyncService, vcr: { cassette_name: 'slack/subteam_service' } do
   let(:expected_names) { ['Test Group 1', 'Test Group 2', 'Test Group 3'] }
   let(:expected_name) { 'Test Group 3' }
   let(:expected_profile_rids) { %w[UL5H1BQTG ULTHYD4UQ UNNQ4U048] }
@@ -15,5 +15,5 @@ RSpec.describe Slack::SubteamService, vcr: { cassette_name: 'slack/subteam_servi
     expected_profile_rids.each { |rid| create(:profile, team:, rid:) }
   end
 
-  include_examples 'SubteamService'
+  include_examples 'SubteamSyncService'
 end

--- a/spec/services/slack/team_sync_service_spec.rb
+++ b/spec/services/slack/team_sync_service_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe Slack::ProfileService, vcr: { cassette_name: 'slack/profile_service' } do
+RSpec.describe Slack::TeamSyncService, vcr: { cassette_name: 'slack/profile_service' } do
   let(:expected_names) { %w[Existing Mark Vincent William Wolfgang] }
 
   before do
     allow(App).to receive(:slack_app_id).and_return('slack-app-id')
   end
 
-  include_examples 'ProfileService'
+  include_examples 'TeamSyncService'
 end

--- a/spec/support/shared_examples/channel_sync_service.rb
+++ b/spec/support/shared_examples/channel_sync_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.shared_examples 'ChannelService' do
+RSpec.shared_examples 'ChannelSyncService' do
   subject(:service) { described_class.call(team:, new_channel_rid:) }
 
   let(:team) { create(:team, api_key: 'api-key', join_channels: true) }

--- a/spec/support/shared_examples/subteam_sync_service.rb
+++ b/spec/support/shared_examples/subteam_sync_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.shared_examples 'SubteamService' do
+RSpec.shared_examples 'SubteamSyncService' do
   subject(:service) { described_class.call(team:) }
 
   let(:team) { create(:team, api_key: 'api-key') }

--- a/spec/support/shared_examples/team_sync_service.rb
+++ b/spec/support/shared_examples/team_sync_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.shared_examples 'ProfileService' do
+RSpec.shared_examples 'TeamSyncService' do
   subject(:service) { described_class.call(team:, first_run:) }
 
   let(:team) { create(:team, api_key: 'api-key') }
@@ -11,7 +11,7 @@ RSpec.shared_examples 'ProfileService' do
   let(:first_run) { false }
 
   before do
-    allow(SubteamWorker).to receive(:perform_async)
+    allow(SubteamSyncWorker).to receive(:perform_async)
     allow(TokenDispersalService).to receive(:call)
     service
   end
@@ -47,8 +47,8 @@ RSpec.shared_examples 'ProfileService' do
       expect(TokenDispersalService).to have_received(:call).with(team:, notify: false)
     end
 
-    it 'invokes SubteamWorker' do
-      expect(SubteamWorker).to have_received(:perform_async).with(team.rid)
+    it 'invokes SubteamSyncWorker' do
+      expect(SubteamSyncWorker).to have_received(:perform_async).with(team.rid)
     end
   end
 end

--- a/spec/workers/channel_sync_worker_spec.rb
+++ b/spec/workers/channel_sync_worker_spec.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe ChannelWorker do
+RSpec.describe ChannelSyncWorker do
   subject(:perform) { described_class.new.perform(team.rid, 'new_channel_rid') }
 
   let(:team) { create(:team) }
 
   before do
     allow(Team).to receive(:find_by!).with(rid: team.rid).and_return(team)
-    allow(Slack::ChannelService).to receive(:call)
+    allow(Slack::ChannelSyncService).to receive(:call)
     perform
   end
 
   it 'calls service with expected args' do
-    expect(Slack::ChannelService)
+    expect(Slack::ChannelSyncService)
       .to have_received(:call).with(team:, new_channel_rid: 'new_channel_rid')
   end
 end

--- a/spec/workers/subteam_sync_worker_spec.rb
+++ b/spec/workers/subteam_sync_worker_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe SubteamWorker do
+RSpec.describe SubteamSyncWorker do
   subject(:perform) { described_class.new.perform(team.rid) }
 
   let(:team) { create(:team) }
 
   before do
-    allow(Slack::SubteamService).to receive(:call)
+    allow(Slack::SubteamSyncService).to receive(:call)
     perform
   end
 
   it 'calls service with expected args' do
-    expect(Slack::SubteamService).to have_received(:call).with(team:)
+    expect(Slack::SubteamSyncService).to have_received(:call).with(team:)
   end
 end

--- a/spec/workers/team_sync_worker_spec.rb
+++ b/spec/workers/team_sync_worker_spec.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe ProfileWorker do
+RSpec.describe TeamSyncWorker do
   subject(:perform) { described_class.new.perform(team.rid, first_run) }
 
   let(:team) { create(:team) }
   let(:first_run) { true }
 
   before do
-    allow(Slack::ProfileService).to receive(:call)
+    allow(Slack::TeamSyncService).to receive(:call)
     perform
   end
 
   it 'calls service with expected args' do
-    expect(Slack::ProfileService).to have_received(:call).with(team:, first_run:)
+    expect(Slack::TeamSyncService).to have_received(:call).with(team:, first_run:)
   end
 end


### PR DESCRIPTION
Adds `distinct` to `join` to fix Subteam dupe member issue (database would reject on unique key). Bonus: rename some services to better describe them.