### PR TITLE
chore: update Dockerfile to reduce the image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV APP_NAME=${APP_NAME} \
     IN_DOCKER=true
 
 RUN apt-get update -qq && \
-    apt-get install -y \
+    apt-get install --no-install-recommends -y \
       build-essential \
       git \
       libmagickwand-dev \
@@ -18,7 +18,7 @@ RUN apt-get update -qq && \
       npm \
       postgresql-client \
       python2 \
-    && apt-get clean
+    && apt-get clean && rm -rf /var/lib/apt/lists/*;
 
 COPY lib/image_magick/policy.xml /etc/ImageMagick-6/policy.xml
 RUN mkdir -p /storage/response_images/cache
@@ -28,7 +28,7 @@ WORKDIR $INSTALL_PATH
 
 COPY . .
 
-RUN npm install yarn -g
+RUN npm install yarn -g && npm cache clean --force;
 RUN yarn install
 RUN gem install bundler && bundle install
 RUN bundle exec rake assets:precompile


### PR DESCRIPTION
Hi there,

I've made a small improvement to the Dockerfile that I think could help optimize the image size.

Summary of the changes:
* I added `npm cache clean` after `npm install` to remove `npm` cache that is not needed inside the Docker image.
* I added the `--no-install-recommends` to with apt-get in order to not install unnecessary packages and reduce the image size.
* I added `rm -rf /var/lib/apt/lists/*` after `apt-get install` which removes unnecessary files and reduces the size of the image.


Impact on the image size:
* Image size before repair: 1.52 GB
* Image size after repair: 1.23 GB
* Difference: 302.91 MB (19.42%)

I hope that you will find these changes useful to you. Let me know if you have any questions or concerns.

Thanks,